### PR TITLE
Add Memori OSS project

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,11 @@ Agentic AI libraries, frameworks and tools: AI agents, workflows, autonomous dec
    Open source version of Manus, the general AI agent  
 
 104. <a href="https://github.com/prithivirajdamodaran/route0x">prithivirajdamodaran/</a><b><a href="https://github.com/prithivirajdamodaran/route0x">Route0x</a></b> ⭐ 116    
-   A production-grade query routing solution, leveraging LLMs while optimizing for cost per query  
+   A production-grade query routing solution, leveraging LLMs while optimizing for cost per query
+
+105. <a href="https://github.com/GibsonAI/memori">Memori/</a><b><a href="https://github.com/GibsonAI/memori">Memori</a></b> ⭐ 1,500   
+   SQL-Native multi-agent memory engine for AI  
+   🔗 [Memori](https://memori.gibsonai.com/)
 
 ## Code Quality
 


### PR DESCRIPTION
Memori is an open-source memory layer to give your AI agents human-like memory. It remembers what matters, promotes what's essential, and injects structured context intelligently into LLM conversations.

With a single line of code `memori.enable()` any LLM gains the ability to remember conversations, learn from interactions, and maintain context across sessions. The entire memory system is stored in a standard SQLite database (or PostgreSQL/MySQL for enterprise deployments), making it fully portable, auditable, and owned by the user.